### PR TITLE
refacotr: AOP를 이용한 관심사 분리

### DIFF
--- a/src/main/java/hello/board/global/annotation/CheckCommentOwner.java
+++ b/src/main/java/hello/board/global/annotation/CheckCommentOwner.java
@@ -1,0 +1,11 @@
+package hello.board.global.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CheckCommentOwner {
+}

--- a/src/main/java/hello/board/global/annotation/CheckPostOwner.java
+++ b/src/main/java/hello/board/global/annotation/CheckPostOwner.java
@@ -1,0 +1,11 @@
+package hello.board.global.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CheckPostOwner {
+}

--- a/src/main/java/hello/board/global/annotation/CreateStatistics.java
+++ b/src/main/java/hello/board/global/annotation/CreateStatistics.java
@@ -1,0 +1,11 @@
+package hello.board.global.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CreateStatistics {
+}

--- a/src/main/java/hello/board/global/aspect/AuthorizationAspect.java
+++ b/src/main/java/hello/board/global/aspect/AuthorizationAspect.java
@@ -1,0 +1,64 @@
+package hello.board.global.aspect;
+
+import hello.board.domain.comment.Comment;
+import hello.board.domain.comment.CommentRepository;
+import hello.board.domain.post.Post;
+import hello.board.domain.post.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ResponseStatusException;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class AuthorizationAspect {
+
+    private final PostRepository postRepository;
+    private final CommentRepository commentRepository;
+
+    @Before("@annotation(hello.board.global.annotation.CheckPostOwner)")
+    public void checkPostOwner(JoinPoint joinPoint) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String loginId = authentication.getName();
+
+        Object[] args = joinPoint.getArgs();
+        Long postId = (Long) args[0];
+
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+
+        if (!post.getUser().getUsername().equals(loginId)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "이 게시글에 대한 권한이 없습니다.");
+        }
+    }
+
+    @Before("@annotation(hello.board.global.annotation.CheckCommentOwner)")
+    public void checkCommentOwner(JoinPoint joinPoint) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String loginId = authentication.getName();
+
+        Long commentId = findId(joinPoint.getArgs());
+
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다."));
+
+        if (!comment.getUser().getUsername().equals(loginId)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "이 댓글에 대한 권한이 없습니다.");
+        }
+    }
+
+    private Long findId(Object[] args) {
+        for (Object arg : args) {
+            if (arg instanceof Long) {
+                return (Long) arg;
+            }
+        }
+        throw new IllegalStateException("메서드 파라미터에서 ID를 찾을 수 없습니다.");
+    }
+}

--- a/src/main/java/hello/board/global/aspect/StatisticsAspect.java
+++ b/src/main/java/hello/board/global/aspect/StatisticsAspect.java
@@ -1,0 +1,27 @@
+package hello.board.global.aspect;
+
+import hello.board.domain.post.PostStatistics;
+import hello.board.infrastructure.persistence.repository.PostStatisticsRepository;
+import hello.board.infrastructure.web.post.response.PostResponse;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class StatisticsAspect {
+
+    private final PostStatisticsRepository postStatisticsRepository;
+
+    @AfterReturning(pointcut = "@annotation(hello.board.global.annotation.CreateStatistics)", returning = "postResponse")
+    public void createPostStatistics(PostResponse postResponse) {
+        if (postResponse == null) return;
+
+        postStatisticsRepository.save(PostStatistics.builder()
+                .postId(String.valueOf(postResponse.getId()))
+                .viewCount(0)
+                .build());
+    }
+}

--- a/src/main/java/hello/board/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/hello/board/global/exception/GlobalExceptionHandler.java
@@ -1,9 +1,11 @@
 package hello.board.global.exception;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.ModelAndView;
 
 @ControllerAdvice
@@ -11,17 +13,23 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(EntityNotFoundException.class)
     public ModelAndView entityNotFoundException(EntityNotFoundException ex, Model model) {
-        ModelAndView mav = new ModelAndView("error/404");
-        model.addAttribute("errorMessage", ex.getMessage());
-        mav.setStatus(HttpStatus.NOT_FOUND);
-        return mav;
+        return createErrorModelAndView("error/404", ex.getMessage(), HttpStatus.NOT_FOUND, model);
     }
 
     @ExceptionHandler(Exception.class)
     public ModelAndView allException(Exception ex, Model model) {
-        ModelAndView mav = new ModelAndView("error/500");
-        model.addAttribute("errorMessage", ex.getMessage());
-        mav.setStatus(HttpStatus.INTERNAL_SERVER_ERROR);
+        return createErrorModelAndView("error/500", ex.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR, model);
+    }
+
+    @ExceptionHandler(ResponseStatusException.class)
+    public ModelAndView handleResponseStatusException(ResponseStatusException ex, Model model) {
+        return createErrorModelAndView("error/403", ex.getReason(), ex.getStatusCode(), model);
+    }
+
+    private ModelAndView createErrorModelAndView(String viewName, String errorMessage, HttpStatusCode status, Model model) {
+        ModelAndView mav = new ModelAndView(viewName);
+        model.addAttribute("errorMessage", errorMessage);
+        mav.setStatus(status);
         return mav;
     }
 }

--- a/src/main/java/hello/board/infrastructure/web/comment/CommentController.java
+++ b/src/main/java/hello/board/infrastructure/web/comment/CommentController.java
@@ -31,18 +31,18 @@ public class CommentController {
 
     @PostMapping("/edit/{commentId}")
     public String updateComment(@PathVariable Long postId, @PathVariable Long commentId,
-                                @RequestParam("content") String content, Principal pri) {
+                                @RequestParam("content") String content) {
         if (content == null || content.trim().isEmpty()) {
             return "redirect:/post/" + postId;
         }
 
-        commentService.updateComment(content, commentId, pri.getName());
+        commentService.updateComment(content, commentId);
         return "redirect:/post/" + postId;
     }
 
     @PostMapping("/delete/{commentId}")
-    public String deleteComment(@PathVariable Long postId, @PathVariable Long commentId, Principal pri) {
-        commentService.deleteComment(commentId, pri.getName());
+    public String deleteComment(@PathVariable Long postId, @PathVariable Long commentId) {
+        commentService.deleteComment(commentId);
 
         return "redirect:/post/" + postId;
     }

--- a/src/main/java/hello/board/infrastructure/web/post/PostController.java
+++ b/src/main/java/hello/board/infrastructure/web/post/PostController.java
@@ -63,12 +63,12 @@ public class PostController {
     }
 
     @PostMapping("/post/create")
-    public String createPost(@Validated @ModelAttribute("form") PostForm form, BindingResult result, Principal pri,
+    public String createPost(@Validated @ModelAttribute("form") PostForm form, BindingResult result,
                              @RequestParam(value = "images", required = false) List<MultipartFile> images) {
         if (result.hasErrors()) {
             return "posts/createPostForm";
         }
-        PostResponse response = postService.savePost(form, images, pri.getName());
+        PostResponse response = postService.savePost(form, images);
         return "redirect:/post/" + response.getId();
     }
 
@@ -97,13 +97,13 @@ public class PostController {
                              @RequestParam(value = "images", required = false) List<MultipartFile> images,
                              @RequestParam(value = "imageIdsToDelete", required = false) List<Long> imageIdsToDelete,
                              Principal pri) {
-        postService.updatePost(postId, form, images, pri.getName(), imageIdsToDelete);
+        postService.updatePost(postId, form, images, imageIdsToDelete);
         return "redirect:/post/" + postId;
     }
 
     @PostMapping("/post/delete/{postId}")
-    public String deletePost(@PathVariable Long postId, Principal pri) {
-        postService.deletePost(postId, pri.getName());
+    public String deletePost(@PathVariable Long postId) {
+        postService.deletePost(postId);
         return "redirect:/";
     }
 }

--- a/src/main/java/hello/board/service/comment/CommentService.java
+++ b/src/main/java/hello/board/service/comment/CommentService.java
@@ -1,5 +1,6 @@
 package hello.board.service.comment;
 
+import hello.board.global.annotation.CheckCommentOwner;
 import hello.board.infrastructure.web.comment.response.CommentResponse;
 import hello.board.domain.comment.Comment;
 import hello.board.domain.post.Post;
@@ -48,19 +49,16 @@ public class CommentService {
         return getCommentDto(post);
     }
 
-    public void updateComment(String content, Long commentId, String username) {
+    @CheckCommentOwner
+    public void updateComment(String content, Long commentId) {
         Comment comment = entityFinder.getComment(commentId);
-        User user = entityFinder.getLoginUser(username);
 
-        checkAuthorization(comment, user);
         comment.updateComment(content);
     }
 
-    public void deleteComment(Long commentId, String loginId) {
+    @CheckCommentOwner
+    public void deleteComment(Long commentId) {
         Comment findComment = entityFinder.getComment(commentId);
-        User user = entityFinder.getLoginUser(loginId);
-
-        checkAuthorization(findComment, user);
 
         if (hasChildren(findComment)) {
             findComment.markAsDeleted();
@@ -102,11 +100,5 @@ public class CommentService {
 
     private static boolean hasNotParent(Comment comment) {
         return comment.getParent() == null;
-    }
-
-    private static void checkAuthorization(Comment findComment, User user) {
-        if (!findComment.getUser().equals(user)) {
-            throw new IllegalArgumentException("권한이 없습니다.");
-        }
     }
 }

--- a/src/main/java/hello/board/service/post/PostService.java
+++ b/src/main/java/hello/board/service/post/PostService.java
@@ -1,17 +1,17 @@
 package hello.board.service.post;
 
+import hello.board.domain.post.Post;
+import hello.board.domain.post.PostRepository;
+import hello.board.domain.user.User;
+import hello.board.global.annotation.CheckPostOwner;
+import hello.board.global.annotation.CreateStatistics;
+import hello.board.infrastructure.persistence.repository.PostQueryRepository;
+import hello.board.infrastructure.web.comment.response.CommentDto;
 import hello.board.infrastructure.web.post.request.PostForm;
 import hello.board.infrastructure.web.post.request.UpdatePostForm;
 import hello.board.infrastructure.web.post.response.*;
-import hello.board.domain.post.Post;
-import hello.board.domain.post.PostStatistics;
-import hello.board.domain.user.User;
-import hello.board.infrastructure.persistence.repository.PostQueryRepository;
-import hello.board.infrastructure.persistence.repository.PostStatisticsRepository;
-import hello.board.domain.post.PostRepository;
 import hello.board.service.EntityFinder;
 import hello.board.service.comment.CommentService;
-import hello.board.infrastructure.web.comment.response.CommentDto;
 import hello.board.service.image.PostImageManager;
 import hello.board.service.image.dto.ImageDto;
 import hello.board.service.poststatistics.ViewService;
@@ -19,6 +19,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -33,35 +34,29 @@ public class PostService {
     private final PostRepository postRepository;
     private final EntityFinder entityFinder;
     private final PostQueryRepository postQueryRepository;
-    private final PostStatisticsRepository postStatisticsRepository;
-    private final ViewService viewService;
     private final CommentService commentService;
+    private final ViewService viewService;
     private final PostImageManager postImageManager;
 
+    @CreateStatistics
     @Transactional
-    public PostResponse savePost(PostForm form, List<MultipartFile> imageFiles, String loginId) {
+    public PostResponse savePost(PostForm form, List<MultipartFile> imageFiles) {
+        String loginId = SecurityContextHolder.getContext().getAuthentication().getName();
         User loginUser = entityFinder.getLoginUser(loginId);
+
         Post post = form.toEntity(loginUser);
         Post savedPost = postRepository.save(post);
 
         processImages(imageFiles, post);
-        createPostStatistics(savedPost.getId());
 
         return PostResponse.of(savedPost);
     }
 
     public PostDetailDto findByPostId(Long postId, HttpServletRequest request) {
         Post post = entityFinder.getPost(postId);
-        updateViewCount(postId, request);
+        viewService.handleView(postId, request);
 
         return createPostDetailDto(postId, post);
-    }
-
-    private PostDetailDto createPostDetailDto(Long postId, Post post) {
-        Integer likeCount = post.getLikeCount();
-        Integer viewCount = viewService.getViewCount(postId);
-
-        return PostDetailDto.of(post, viewCount, likeCount);
     }
 
     public PostWithCommentsDto findPostWithComments(Long postId, HttpServletRequest request) {
@@ -84,24 +79,22 @@ public class PostService {
                 .build();
     }
 
+    @CheckPostOwner
     @Transactional
-    public PostResponse updatePost(Long postId, UpdatePostForm form, List<MultipartFile> imageFiles, String loginId, List<Long> imageIdsToDelete) {
+    public PostResponse updatePost(Long postId, UpdatePostForm form, List<MultipartFile> imageFiles, List<Long> imageIdsToDelete) {
         Post post = entityFinder.getPost(postId);
-        User loginUser = entityFinder.getLoginUser(loginId);
 
-        validatePostOwnership(post.getUser(), loginUser);
         processImageUpdates(imageFiles, imageIdsToDelete, post);
         updatePostContent(form, post);
 
         return PostResponse.of(post);
     }
 
+    @CheckPostOwner
     @Transactional
-    public void deletePost(Long id, String loginId) {
+    public void deletePost(Long id) {
         Post post = entityFinder.getPost(id);
-        User loginUser = entityFinder.getLoginUser(loginId);
 
-        validatePostOwnership(post.getUser(), loginUser);
         postImageManager.deleteAllImages(post);
         postRepository.delete(post);
     }
@@ -110,14 +103,17 @@ public class PostService {
         return postQueryRepository.searchPosts(search, page);
     }
 
+    private PostDetailDto createPostDetailDto(Long postId, Post post) {
+        Integer likeCount = post.getLikeCount();
+        Integer viewCount = viewService.getViewCount(postId);
+
+        return PostDetailDto.of(post, viewCount, likeCount);
+    }
+
     private void processImages(List<MultipartFile> imageFiles, Post post) {
         if (postImageManager.hasImageFiles(imageFiles)) {
             postImageManager.saveImagesToPost(imageFiles, post);
         }
-    }
-
-    private void updateViewCount(Long postId, HttpServletRequest request) {
-        viewService.handleView(postId, request);
     }
 
     private static void updatePostContent(UpdatePostForm form, Post post) {
@@ -133,17 +129,4 @@ public class PostService {
         }
     }
 
-    private void createPostStatistics(Long postId) {
-        PostStatistics statistics = PostStatistics.builder()
-                .postId(String.valueOf(postId))
-                .viewCount(0)
-                .build();
-        postStatisticsRepository.save(statistics);
-    }
-
-    private void validatePostOwnership(User postOwner, User currentUser) {
-        if (!postOwner.equals(currentUser)) {
-            throw new IllegalArgumentException("이 게시글을 수정할 권한이 없습니다.");
-        }
-    }
 }

--- a/src/main/java/hello/board/service/poststatistics/LikeService.java
+++ b/src/main/java/hello/board/service/poststatistics/LikeService.java
@@ -1,9 +1,9 @@
 package hello.board.service.poststatistics;
 
 import hello.board.domain.like.Like;
+import hello.board.domain.like.LikeRepository;
 import hello.board.domain.post.Post;
 import hello.board.domain.user.User;
-import hello.board.domain.like.LikeRepository;
 import hello.board.service.EntityFinder;
 import hello.board.service.poststatistics.dto.LikeResponse;
 import jakarta.persistence.OptimisticLockException;

--- a/src/main/resources/templates/error/403.html
+++ b/src/main/resources/templates/error/403.html
@@ -1,0 +1,63 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>500 - Internal Server Error</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            background-color: #f8f9fa;
+            margin: 0;
+            padding: 0;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            height: 100vh;
+        }
+        .container {
+            text-align: center;
+            max-width: 600px;
+            background-color: white;
+            padding: 40px;
+            box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+            border-radius: 10px;
+        }
+        h2 {
+            font-size: 48px;
+            color: #dc3545;
+        }
+        p {
+            font-size: 18px;
+            color: #6c757d;
+        }
+        .error-icon {
+            font-size: 100px;
+            color: #dc3545;
+            animation: shake 0.5s;
+        }
+        @keyframes shake {
+            0%, 100% { transform: translateX(0); }
+            25%, 75% { transform: translateX(-10px); }
+            50% { transform: translateX(10px); }
+        }
+        a {
+            color: #007bff;
+            text-decoration: none;
+        }
+        a:hover {
+            text-decoration: underline;
+        }
+    </style>
+</head>
+<body>
+<div class="container">
+    <div>
+        <div class="error-icon">⚠️</div>
+        <h2>403 - FORBIDDEN</h2>
+        <p>권한이 없습니다. 다시 확인해주세요.</p>
+        <a href="/">홈페이지로 돌아가기</a>
+    </div>
+</div>
+</body>
+</html>

--- a/src/test/java/hello/board/controller/post/PostControllerTest.java
+++ b/src/test/java/hello/board/controller/post/PostControllerTest.java
@@ -171,11 +171,13 @@ class PostControllerTest extends ControllerTestSupport {
                         .param("content", updatePostForm.getContent())
                 )
                 .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/post/" + savedPost.getId()))
                 .andDo(print());
 
         //then
-        assertThat(savedPost.getTitle()).isEqualTo("라멘");
-        assertThat(savedPost.getContent()).isEqualTo("츠케멘");
+        Post updatedPost = postRepository.findById(savedPost.getId()).get();
+        assertThat(updatedPost.getTitle()).isEqualTo("라멘");
+        assertThat(updatedPost.getContent()).isEqualTo("츠케멘");
     }
 
     @DisplayName("게시글 수정 권한이 없는 경우 오류가 발생한다.")
@@ -196,7 +198,7 @@ class PostControllerTest extends ControllerTestSupport {
                         .param("title", updatePostForm.getTitle())
                         .param("content", updatePostForm.getContent())
                 )
-                .andExpect(status().isInternalServerError())
+                .andExpect(status().isForbidden())
                 .andDo(print());
     }
 

--- a/src/test/java/hello/board/service/comment/CommentServiceTest.java
+++ b/src/test/java/hello/board/service/comment/CommentServiceTest.java
@@ -10,6 +10,7 @@ import hello.board.infrastructure.web.comment.response.CommentDto;
 import hello.board.infrastructure.web.comment.request.CommentForm;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.security.test.context.support.WithMockUser;
 
 import java.util.List;
 import java.util.Optional;
@@ -85,7 +86,7 @@ class CommentServiceTest extends IntegrationTestSupport {
                 .parent(comment1)
                 .content("댓글3")
                 .build();
-        commentRepository.saveAll(List.of(comment1,comment2,comment3));
+        commentRepository.saveAll(List.of(comment1, comment2, comment3));
 
         commentRepository.flush();
         postRepository.flush();
@@ -102,6 +103,7 @@ class CommentServiceTest extends IntegrationTestSupport {
 
     @DisplayName("자식댓글이 있는 부모댓글을 삭제하면 부모댓글은 삭제되지 않고 삭제된 것으로 표시된다.")
     @Test
+    @WithMockUser(username = "wss3325")
     void delete() throws Exception {
         //given
         User user = User.builder()
@@ -135,7 +137,7 @@ class CommentServiceTest extends IntegrationTestSupport {
 
         em.clear();
         //when
-        commentService.deleteComment(comment1.getId(), user.getUsername());
+        commentService.deleteComment(comment1.getId());
 
         //then
         Optional<Comment> result = commentRepository.findById(comment1.getId());
@@ -144,6 +146,7 @@ class CommentServiceTest extends IntegrationTestSupport {
     }
 
     @Test
+    @WithMockUser(username = "wss3325")
     void update() throws Exception {
         //given
         User user = User.builder()
@@ -168,7 +171,7 @@ class CommentServiceTest extends IntegrationTestSupport {
         commentRepository.save(comment);
 
         //when
-        commentService.updateComment("수정된 댓글", comment.getId(), user.getUsername());
+        commentService.updateComment("수정된 댓글", comment.getId());
 
         //then
         assertThat(comment.getContent()).isEqualTo("수정된 댓글");

--- a/src/test/java/hello/board/service/post/PostServiceTest.java
+++ b/src/test/java/hello/board/service/post/PostServiceTest.java
@@ -1,17 +1,24 @@
 package hello.board.service.post;
 
 import hello.board.IntegrationTestSupport;
-import hello.board.infrastructure.web.post.response.PostResponse;
 import hello.board.domain.Role;
 import hello.board.domain.post.Post;
 import hello.board.domain.user.User;
 import hello.board.global.exception.EntityNotFoundException;
 import hello.board.infrastructure.web.post.request.UpdatePostForm;
+import hello.board.infrastructure.web.post.response.PostResponse;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class PostServiceTest extends IntegrationTestSupport {
 
@@ -52,6 +59,7 @@ class PostServiceTest extends IntegrationTestSupport {
     }
 
     @Test
+    @WithMockUser(username = "wss3325")
     void updatePost() throws Exception {
         //given
         User user = User.builder()
@@ -74,14 +82,54 @@ class PostServiceTest extends IntegrationTestSupport {
                 .build();
 
         //when
-        PostResponse response = postService.updatePost(post.getId(), form, null, user.getUsername(), null);
+        PostResponse response = postService.updatePost(post.getId(), form, null, null);
 
         //then
         assertThat(response.getTitle()).isEqualTo("수정된 제목");
         assertThat(response.getContent()).isEqualTo("수정된 내용");
     }
 
+    @DisplayName("다른 사람이 작성한 게시글을 수정하면 예외가 발생한다.")
     @Test
+    @WithMockUser(username = "otherUser")
+    void updatePostException() throws Exception {
+        //given
+        User owner = User.builder()
+                .username("wss3325")
+                .nickname("keke")
+                .password("1234")
+                .grade(Role.USER)
+                .build();
+        User otherUser = User.builder()
+                .username("otherUser")
+                .nickname("hihi")
+                .password("3454")
+                .grade(Role.USER)
+                .build();
+        userRepository.saveAll(List.of(owner, otherUser));
+
+        Post post = Post.builder()
+                .title("제목")
+                .content("내용")
+                .user(owner)
+                .build();
+        postRepository.save(post);
+
+        UpdatePostForm form = UpdatePostForm.builder()
+                .title("수정된 제목")
+                .content("수정된 내용")
+                .build();
+
+        // expect
+        ResponseStatusException e = assertThrows(ResponseStatusException.class,
+                () -> postService.updatePost(post.getId(), form, null, null));
+
+        assertThat(e.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+        assertThat(e.getReason()).isEqualTo("이 게시글에 대한 권한이 없습니다.");
+    }
+
+    @Test
+    @WithMockUser(username = "wss3325")
     void delete() throws Exception {
         //given
         User user = User.builder()
@@ -99,7 +147,7 @@ class PostServiceTest extends IntegrationTestSupport {
         postRepository.save(post);
 
         //when
-        postService.deletePost(post.getId(), user.getUsername());
+        postService.deletePost(post.getId());
 
         //then
         assertThat(postRepository.findById(post.getId())).isEmpty();


### PR DESCRIPTION
- PostService, CommentService의 반복적인 권한 확인 로직을 AOP로 분리
- @CheckPostOwner, @CheckCommentOwner 어노테이션을 사용한 권한 검사 구현
- 게시글 생성 후 통계 생성 로직을 @AfterReturning AOP로 분리하여 서비스 로직의 책임 단순화